### PR TITLE
BloonsTD6: fix bug with generating games with multiple bloons players

### DIFF
--- a/worlds/bloonstd6/__init__.py
+++ b/worlds/bloonstd6/__init__.py
@@ -112,8 +112,6 @@ class BTD6World(World):
             self.multiworld.itempool.append(self.create_item(name))
             total_items -= 1
 
-        numMedals = len(all_map_keys) * self.options.rando_difficulty.value
-
         for _ in range(len(all_map_keys) * self.options.rando_difficulty.value):
             self.multiworld.itempool.append(self.create_item(BloonsItems.MEDAL_NAME))
             total_items -= 1


### PR DESCRIPTION
## What is this fixing or adding?
This addresses a bug where, when multiple players were playing Bloons, the generator would compound their selected maps together. The solution was to move the initialization of Map and Monkey arrays to inside the generate_early() function.

I also did a little bit of code sorting in generate_early to keep similar functionality together without breaking generation.

## How was this tested?
I ran Generate with a print statement nested in the create_items function that would print the full map lists.
I also checked the log to verify that the generated location lists were unique.